### PR TITLE
Add logging

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,26 @@
+---
+name: Build
+description: Build the project
+inputs:
+  working_directory:
+    description: 'Working directory'
+    required: false
+    default: .
+runs:
+    using: "composite"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: AleksanderWWW/abcd-graph
+          path: ${{ inputs.working_directory }}
+
+      - name: Install poetry
+        working-directory: ${{ inputs.working_directory }}
+        run: pip install --upgrade poetry
+        shell: bash
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working_directory }}
+        run: poetry install
+        shell: bash

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -9,22 +9,6 @@ inputs:
 runs:
     using: "composite"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          repository:  AleksanderWWW/abcd-graph
-          path: ${{ inputs.working_directory }}
-
-      - name: Install poetry
-        working-directory: ${{ inputs.working_directory }}
-        run: pip install --upgrade poetry
-        shell: bash
-
-      - name: Install dependencies
-        working-directory: ${{ inputs.working_directory }}
-        run: poetry install
-        shell: bash
-
       - name: Run tests
         working-directory: ${{ inputs.working_directory }}
         run: poetry run pytest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Build
+        uses: ./.github/actions/build
+
       - name: Test
         uses: ./.github/actions/test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,6 @@
 
 ### Changes
 - Add default values for `ABCDParams` ([#1](https://github.com/AleksanderWWW/abcd-graph/pull/1))
+
+### Features
+- Add `logger` param to enable logging during graph generation ([#9](https://github.com/AleksanderWWW/abcd-graph/pull/9))

--- a/src/abcd_graph/abcd.py
+++ b/src/abcd_graph/abcd.py
@@ -36,24 +36,41 @@ from abcd_graph.core import (
     build_degrees,
     split_degrees,
 )
+from abcd_graph.logger import (
+    LoggerType,
+    construct_logger,
+)
 
 if TYPE_CHECKING:
     from abcd_graph.abcd_params import ABCDParams
 
 
-def generate_abcd(*, params: "ABCDParams", n: int = 1000) -> tuple[list[list[Any]], list[list[Any]]]:
+def generate_abcd(
+    *,
+    params: "ABCDParams",
+    n: int = 1000,
+    logger: LoggerType = False,
+) -> tuple[list[list[Any]], list[list[Any]]]:
     """
     < short description >
     :param params: ABCD input params (ABCDParams)
     :param n: number of vertices (int) - defaults to 1000
+    :param logger: logger object (ABCDLogger | bool) - defaults to False
     :return:
     """
+    abcd_logger = construct_logger(logger)
+
+    abcd_logger.info("Generating ABCD graph")
+
+    abcd_logger.info("Building degrees")
     degrees = build_degrees(
         n,
         params.gamma,
         params.delta,
         params.zeta,
     )
+
+    abcd_logger.info("Building community sizes")
 
     community_sizes = build_community_sizes(
         n,
@@ -62,14 +79,26 @@ def generate_abcd(*, params: "ABCDParams", n: int = 1000) -> tuple[list[list[Any
         params.tau,
     )
 
+    abcd_logger.info("Building communities")
+
     communities = build_communities(community_sizes)
+
+    abcd_logger.info("Assigning degrees")
 
     deg = assign_degrees(degrees, communities, community_sizes, params.xi)
 
+    abcd_logger.info("Splitting degrees")
+
     deg_c, deg_b = split_degrees(deg, communities, params.xi)
+
+    abcd_logger.info("Building community edges")
 
     community_edges = build_community_edges(deg_c, communities)
 
+    abcd_logger.info("Building background edges")
+
     background_edges = build_background_edges(deg_b)
+
+    abcd_logger.info("ABCD graph generated")
 
     return community_edges, background_edges

--- a/src/abcd_graph/logger.py
+++ b/src/abcd_graph/logger.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2024 Jordan Barrett
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+__all__ = [
+    "ABCDLogger",
+    "LoggerType",
+    "construct_logger",
+]
+
+import logging
+import os
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from typing import Union
+
+from typing_extensions import TypeAlias
+
+
+class ABCDLogger(ABC):
+    @abstractmethod
+    def info(self, message: str) -> None:
+        pass
+
+    @abstractmethod
+    def debug(self, message: str) -> None:
+        pass
+
+    @abstractmethod
+    def warning(self, message: str) -> None:
+        pass
+
+    @abstractmethod
+    def error(self, message: str) -> None:
+        pass
+
+    @abstractmethod
+    def critical(self, message: str) -> None:
+        pass
+
+
+class NoOpLogger(ABCDLogger):
+    def info(self, message: str) -> None:
+        pass
+
+    def debug(self, message: str) -> None:
+        pass
+
+    def warning(self, message: str) -> None:
+        pass
+
+    def error(self, message: str) -> None:
+        pass
+
+    def critical(self, message: str) -> None:
+        pass
+
+
+class StdOutLogger(ABCDLogger):
+    NAME = "abcd-graph"
+
+    def __init__(self) -> None:
+        logging_level = int(os.getenv("ABCD_LOGGING_LEVEL", logging.INFO))
+        logging.basicConfig(
+            level=logging_level,
+            format="[%(name)s] - %(asctime)s - %(levelname)s - %(message)s",
+        )
+        self.logger = logging.getLogger(self.NAME)
+
+    def info(self, message: str) -> None:
+        self.logger.info(message)
+
+    def debug(self, message: str) -> None:
+        self.logger.debug(message)
+
+    def warning(self, message: str) -> None:
+        self.logger.warning(message)
+
+    def error(self, message: str) -> None:
+        self.logger.error(message)
+
+    def critical(self, message: str) -> None:
+        self.logger.critical(message)
+
+
+LoggerType: TypeAlias = Union[ABCDLogger, bool]
+
+
+def construct_logger(logger: LoggerType) -> ABCDLogger:
+    if isinstance(logger, bool):
+        return StdOutLogger() if logger else NoOpLogger()
+
+    return logger

--- a/src/abcd_graph/logger.py
+++ b/src/abcd_graph/logger.py
@@ -83,6 +83,7 @@ class StdOutLogger(ABCDLogger):
             level=logging_level,
             format="[%(name)s] - %(asctime)s - %(levelname)s - %(message)s",
         )
+        self.logging_level = logging_level
         self.logger = logging.getLogger(self.NAME)
 
     def info(self, message: str) -> None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2024 Jordan Barrett
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import logging
+import os
+from unittest.mock import patch
+
+from abcd_graph.logger import (
+    ABCDLogger,
+    NoOpLogger,
+    StdOutLogger,
+    construct_logger,
+)
+
+
+class MockLogger(ABCDLogger):
+    def info(self, message: str) -> None:
+        pass
+
+    def debug(self, message: str) -> None:
+        pass
+
+    def warning(self, message: str) -> None:
+        pass
+
+    def error(self, message: str) -> None:
+        pass
+
+    def critical(self, message: str) -> None:
+        pass
+
+
+def test_construct_logger():
+    mock_logger = MockLogger()
+
+    assert isinstance(construct_logger(False), NoOpLogger)
+    assert isinstance(construct_logger(True), StdOutLogger)
+    assert construct_logger(mock_logger) == mock_logger
+
+
+def test_default_logging_level(caplog):
+    logger = StdOutLogger()
+    caplog.set_level(logger.logging_level)
+
+    logger.debug("debug")
+    logger.info("info")
+    logger.warning("warning")
+    logger.error("error")
+    logger.critical("critical")
+
+    captured_stdout = caplog.text
+
+    assert "debug" not in captured_stdout
+    assert "info" in captured_stdout
+    assert "warning" in captured_stdout
+    assert "error" in captured_stdout
+    assert "critical" in captured_stdout
+
+
+@patch.dict(os.environ, {"ABCD_LOGGING_LEVEL": f"{logging.CRITICAL}"})
+def test_env_var_for_logging_level(caplog):
+    logger = StdOutLogger()
+    caplog.set_level(logger.logging_level)
+
+    logger.debug("debug")
+    logger.info("info")
+    logger.warning("warning")
+    logger.error("error")
+    logger.critical("critical")
+
+    captured_stdout = caplog.text
+
+    assert "debug" not in captured_stdout
+    assert "info" not in captured_stdout
+    assert "warning" not in captured_stdout
+    assert "error" not in captured_stdout
+    assert "critical" in captured_stdout


### PR DESCRIPTION
## What this PR does

Introduce a logging functionality that will help us keep track of what is happening during the graph generation process.

```
>>> generate_abcd(params=params, n=1_000_000)  # no logging by default
```
---

```
>>> generate_abcd(params=params, n=1_000_000, logger=True)

[abcd-graph] - 2024-04-22 19:37:08,427 - INFO - Generating ABCD graph
[abcd-graph] - 2024-04-22 19:37:08,427 - INFO - Building degrees
[abcd-graph] - 2024-04-22 19:37:08,497 - INFO - Building community sizes
[abcd-graph] - 2024-04-22 19:37:08,508 - INFO - Building communities
[abcd-graph] - 2024-04-22 19:37:08,544 - INFO - Assigning degrees
[abcd-graph] - 2024-04-22 19:37:09,537 - INFO - Splitting degrees
[abcd-graph] - 2024-04-22 19:37:11,143 - INFO - Building community edges
[abcd-graph] - 2024-04-22 19:37:14,460 - INFO - Building background edges
[abcd-graph] - 2024-04-22 19:37:16,356 - INFO - ABCD graph generated
```

---

You can also write your own logger (e.g. to write log to a file) by inheriting from `ABCDLogger` and overwritting its abstract methods:

```
from abcd_graph.logger import ABCDLogger

class MyLogger(ABCDLogger):
    ...  # overwrite 'debug', 'info', 'warning', 'error' and 'critical' methods

```
Use your custom logger in the generation function

```
>>> generate_abcd(params=params, n=1_000_000, logger=MyLogger())
```


