### PR TITLE
feat(interface): Add alternative interface via top level ABCD class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Features
+- Added top level ABCD object, an alternative interface that effectively adds a .sample() method to the ABCDParams. ([#67](https://github.com/AleksanderWWW/abcd-graph/pull/67))
+
 ## abcd-graph 0.4.1
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ params = ABCDParams(vcount=1000)
 graph = ABCDGraph(params, logger=True).build()
 ```
 
+Or for an alternative interface
+```python
+from abcd_graph import ABCD
+
+abcd_sampler = ABCD(1000) # vcount is required, other ABCDParams are keyword args
+graph = abcd_sampler.sample() # return a built ABCDGraph object
+```
+
 ### Parameters
 
 - `params`: An instance of `ABCDParams` class.

--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "e9e64ff7-a4cb-4ac8-b9c5-d662aff7e80a",
    "metadata": {},
    "outputs": [
@@ -54,13 +54,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "gamma=2.5 delta=5 zeta=0.5 beta=1.5 s=20 tau=0.8 xi=0.25\n"
+      "ABCDParams(vcount=100, gamma=2.5, beta=1.5, xi=0.25, min_degree=5, max_degree=30, min_community_size=20, max_community_size=25, degree_sequence=None, community_size_sequence=None, num_outliers=0)\n"
      ]
     }
    ],
    "source": [
-    "params = ABCDParams()\n",
-    "G = ABCDGraph(params, n=100, callbacks=[stats, vis, props])\n",
+    "params = ABCDParams(vcount=100, max_community_size=35)\n",
+    "G = ABCDGraph(params, callbacks=[stats, vis, props])\n",
     "G.build()\n",
     "print(params)"
    ]
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "53fccabe-1837-4125-96a9-16651f2d1511",
    "metadata": {},
    "outputs": [
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "69c0cabf-904f-435c-bb63-26c412d43473",
    "metadata": {},
    "outputs": [
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "9d16b234-c7a9-4e13-ab41-6788cc186ebe",
    "metadata": {},
    "outputs": [
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "a659166e-a817-4b8e-8fa2-48fa9ba4a6bf",
    "metadata": {},
    "outputs": [
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "64b006a5-dfe7-49c2-bb18-4b0a5626c797",
    "metadata": {},
    "outputs": [
@@ -250,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "6620a1e7-7eb5-4aa9-84b1-a1afd62025c9",
    "metadata": {},
    "outputs": [
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "49b978d5-eba0-492d-82a7-b126bed97ef0",
    "metadata": {},
    "outputs": [
@@ -323,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "02b27e7c-d799-4a8b-b642-84db0cff29b8",
    "metadata": {},
    "outputs": [
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "64ea46be-5da1-4e49-8ae4-34eababf67f9",
    "metadata": {},
    "outputs": [
@@ -394,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "8a61565c-3acb-46ac-b0c6-9a198a00fd1a",
    "metadata": {},
    "outputs": [
@@ -420,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "e87207bb-3c98-4db7-a54e-2de991643359",
    "metadata": {},
    "outputs": [
@@ -508,6 +508,109 @@
     "    print('number of collisions = ',stats.statistics['number_of_loops']+stats.statistics['number_of_multi_edges'])\n",
     "    print('time_to_build = ',stats.statistics['time_to_build'],'\\n')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c03a4fe",
+   "metadata": {},
+   "source": [
+    "# Alternative Interface\n",
+    "\n",
+    "There is another ABCD interface that effectively adds a .sample() method to the ABCDParams class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "290408f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from abcd_graph import ABCD"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ce9619e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<abcd_graph.graph.graph.ABCDGraph at 0x1153f0910>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "abcd_sampler = ABCD(1000) # vcount is now required\n",
+    "graph = abcd_sampler.sample()\n",
+    "graph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d87a411d",
+   "metadata": {},
+   "source": [
+    "Calling .sample() multiple times samples different ABCDGraphs with the same parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7997dd77",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph2 = abcd_sampler.sample()\n",
+    "graph2 is graph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46d9c7b4",
+   "metadata": {},
+   "source": [
+    "Other ABCD parameters can be set with keyword arguments in the ABCD construction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b30b5d00",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<abcd_graph.graph.graph.ABCDGraph at 0x1153f0b90>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "abcdo_sampler = ABCD(1000, num_outliers=100)\n",
+    "abcdo_sampler.sample()"
+   ]
   }
  ],
  "metadata": {
@@ -526,7 +629,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,

--- a/src/abcd_graph/__init__.py
+++ b/src/abcd_graph/__init__.py
@@ -24,5 +24,8 @@ __all__ = [
     "ABCD",
 ]
 
-from abcd_graph.graph import ABCDGraph, ABCD
+from abcd_graph.graph import (
+    ABCDGraph,
+    ABCD
+)
 from abcd_graph.params import ABCDParams

--- a/src/abcd_graph/__init__.py
+++ b/src/abcd_graph/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 from abcd_graph.graph import (
-    ABCD
+    ABCD,
     ABCDGraph,
 )
 from abcd_graph.params import ABCDParams

--- a/src/abcd_graph/__init__.py
+++ b/src/abcd_graph/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 from abcd_graph.graph import (
-    ABCDGraph,
     ABCD
+    ABCDGraph,
 )
 from abcd_graph.params import ABCDParams

--- a/src/abcd_graph/__init__.py
+++ b/src/abcd_graph/__init__.py
@@ -21,7 +21,8 @@
 __all__ = [
     "ABCDGraph",
     "ABCDParams",
+    "ABCD",
 ]
 
-from abcd_graph.graph import ABCDGraph
+from abcd_graph.graph import ABCDGraph, ABCD
 from abcd_graph.params import ABCDParams

--- a/src/abcd_graph/graph/__init__.py
+++ b/src/abcd_graph/graph/__init__.py
@@ -1,4 +1,5 @@
-__all__ = ["ABCDGraph"]
+__all__ = ["ABCDGraph", "ABCD"]
 
 
 from abcd_graph.graph.graph import ABCDGraph
+from abcd_graph.graph.abcd import ABCD

--- a/src/abcd_graph/graph/__init__.py
+++ b/src/abcd_graph/graph/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ["ABCDGraph", "ABCD"]
 
 
-from abcd_graph.graph.graph import ABCDGraph
 from abcd_graph.graph.abcd import ABCD
+from abcd_graph.graph.graph import ABCDGraph

--- a/src/abcd_graph/graph/abcd.py
+++ b/src/abcd_graph/graph/abcd.py
@@ -1,0 +1,121 @@
+import numpy as np
+from numpy.typing import NDArray
+from typing import Sequence
+
+from abcd_graph.callbacks.abstract import ABCDCallback
+from abcd_graph.graph import ABCDGraph
+from abcd_graph.params import ABCDParams
+from abcd_graph.models import Model
+
+
+__all__ = ["ABCD"]
+
+
+class ABCD:
+    """Artificial Benchmark for Community Detection
+
+    This class combines the ABCDGraph and ABCDParams class, essentially adding a sample
+    method to ABCDParams.
+
+    Parameters
+    ----------
+
+    vcount : int
+        The number of vertices in the graph.
+
+    gamma : float, default=2.5
+        Powerlaw exponent for the degree distribution. Not used if degree_sequence is passed.
+
+    beta: float, default=1.5
+        Powerlaw exponent for the community size distribution. Not used if a custom
+        community_size_sequence is passed.
+    
+    xi: float, default=0.25
+        Proportion of edges in the global background graph. Setting xi=0 gives disjoint communities
+        while xi=1 gives a random graph with no community structure.
+
+    min_degree : int,  default=5
+        Minimum degree in the graph. Not used if degree_sequence is passed.
+
+    max_degree : int, default=30
+        Maximum degree in the graph. Not used if degree_sequence is passed.
+
+    min_community_size : int, default=20
+        Minimum community size. Not used if a custom community_size_sequence is passed.
+
+    max_community_size: int, default=250
+        Maximum community size. Not used if a custom community_size_sequence is passed.
+        
+    degree_sequence : Sequence[int] | NDArray[np.int64] | None, default=None
+        Used to pass a custom degree sequence that overrides the default powerlaw distribution.
+    
+    community_size_sequence : Sequence[int] | NDArray[np.int64] | None, default=None
+        Used to pass a custom community size sequence that overrides the default powerlaw distribution.
+        The sum of the community sizes must equal the number of vertices minus the number of outliers.
+    
+    num_outliers : int, default=0
+        The number of outliers. These vertices have their entire degree in the global background graph
+        so do not appear in any community.
+    
+    model : Model | None, default=None
+        Random graph model used to sample the community and background graphs.
+    
+    verbose : bool, default=False
+        Flag to log runtime infomation.
+    """
+    def __init__(
+        self,
+        vcount: int,
+        gamma: float = 2.5,
+        beta: float = 1.5,
+        xi: float = 0.25,
+        min_degree: int = 5,
+        max_degree: int = 30,
+        min_community_size: int = 20,
+        max_community_size: int = 250,
+        degree_sequence: Sequence[int] | NDArray[np.int64] | None = None,
+        community_size_sequence: Sequence[int] | NDArray[np.int64] | None = None,
+        num_outliers: int = 0,
+        model: Model | None = None,
+        verbose: bool = False,
+    ):
+        self.vcount = vcount
+        self.xi = xi
+        self.min_degree = min_degree
+        self.max_degree = max_degree
+        self.gamma = gamma
+        self.min_community_size = min_community_size
+        self.max_community_size = max_community_size
+        self.beta = beta
+        self.degree_sequence = degree_sequence
+        self.community_size_sequence = community_size_sequence
+        self.num_outliers = num_outliers
+        self.model = model
+        self.verbose = verbose
+    
+    def sample(self, callbacks: list[ABCDCallback] | None = None) -> ABCDGraph:
+        """Sample an ABCD graph. Calling sample multiple times will overwrite the
+        self.graph_ object."""
+        self.params_ = ABCDParams(
+            self.vcount,
+            self.gamma  if self.degree_sequence is None else None,
+            self.beta if self.community_size_sequence is None else None,
+            self.xi,
+            self.min_degree if self.degree_sequence is None else None,
+            self.max_degree if self.degree_sequence is None else None,
+            self.min_community_size if self.community_size_sequence is None else None,
+            self.max_community_size if self.community_size_sequence is None else None,
+            self.degree_sequence,
+            self.community_size_sequence,
+            self.num_outliers,
+        )
+
+        self.graph_ = ABCDGraph(
+            self.params_,
+            logger = self.verbose,
+            callbacks = callbacks,
+        )
+
+        self.graph_.build(self.model)
+
+        return self.graph_

--- a/src/abcd_graph/graph/abcd.py
+++ b/src/abcd_graph/graph/abcd.py
@@ -7,7 +7,6 @@ from abcd_graph.graph import ABCDGraph
 from abcd_graph.params import ABCDParams
 from abcd_graph.models import Model
 
-
 __all__ = ["ABCD"]
 
 
@@ -29,7 +28,7 @@ class ABCD:
     beta: float, default=1.5
         Powerlaw exponent for the community size distribution. Not used if a custom
         community_size_sequence is passed.
-    
+
     xi: float, default=0.25
         Proportion of edges in the global background graph. Setting xi=0 gives disjoint communities
         while xi=1 gives a random graph with no community structure.
@@ -45,24 +44,25 @@ class ABCD:
 
     max_community_size: int, default=250
         Maximum community size. Not used if a custom community_size_sequence is passed.
-        
+
     degree_sequence : Sequence[int] | NDArray[np.int64] | None, default=None
         Used to pass a custom degree sequence that overrides the default powerlaw distribution.
-    
+
     community_size_sequence : Sequence[int] | NDArray[np.int64] | None, default=None
         Used to pass a custom community size sequence that overrides the default powerlaw distribution.
         The sum of the community sizes must equal the number of vertices minus the number of outliers.
-    
+
     num_outliers : int, default=0
         The number of outliers. These vertices have their entire degree in the global background graph
         so do not appear in any community.
-    
+
     model : Model | None, default=None
         Random graph model used to sample the community and background graphs.
-    
+
     verbose : bool, default=False
         Flag to log runtime infomation.
     """
+
     def __init__(
         self,
         vcount: int,
@@ -92,13 +92,13 @@ class ABCD:
         self.num_outliers = num_outliers
         self.model = model
         self.verbose = verbose
-    
+
     def sample(self, callbacks: list[ABCDCallback] | None = None) -> ABCDGraph:
         """Sample an ABCD graph. Calling sample multiple times will overwrite the
         self.graph_ object."""
         self.params_ = ABCDParams(
             self.vcount,
-            self.gamma  if self.degree_sequence is None else None,
+            self.gamma if self.degree_sequence is None else None,
             self.beta if self.community_size_sequence is None else None,
             self.xi,
             self.min_degree if self.degree_sequence is None else None,
@@ -112,8 +112,8 @@ class ABCD:
 
         self.graph_ = ABCDGraph(
             self.params_,
-            logger = self.verbose,
-            callbacks = callbacks,
+            logger=self.verbose,
+            callbacks=callbacks,
         )
 
         self.graph_.build(self.model)

--- a/src/abcd_graph/graph/abcd.py
+++ b/src/abcd_graph/graph/abcd.py
@@ -1,11 +1,13 @@
+from typing import Sequence
+
 import numpy as np
 from numpy.typing import NDArray
-from typing import Sequence
+
 
 from abcd_graph.callbacks.abstract import ABCDCallback
 from abcd_graph.graph import ABCDGraph
-from abcd_graph.params import ABCDParams
 from abcd_graph.models import Model
+from abcd_graph.params import ABCDParams
 
 __all__ = ["ABCD"]
 
@@ -13,8 +15,8 @@ __all__ = ["ABCD"]
 class ABCD:
     """Artificial Benchmark for Community Detection
 
-    This class combines the ABCDGraph and ABCDParams class, essentially adding a sample
-    method to ABCDParams.
+    This class combines the ABCDGraph and ABCDParams class, essentially adding a
+    sample method to ABCDParams.
 
     Parameters
     ----------
@@ -23,15 +25,17 @@ class ABCD:
         The number of vertices in the graph.
 
     gamma : float, default=2.5
-        Powerlaw exponent for the degree distribution. Not used if degree_sequence is passed.
+        Powerlaw exponent for the degree distribution. Not used if
+        degree_sequence is passed.
 
     beta: float, default=1.5
-        Powerlaw exponent for the community size distribution. Not used if a custom
-        community_size_sequence is passed.
+        Powerlaw exponent for the community size distribution. Not used if a
+        custom community_size_sequence is passed.
 
     xi: float, default=0.25
-        Proportion of edges in the global background graph. Setting xi=0 gives disjoint communities
-        while xi=1 gives a random graph with no community structure.
+        Proportion of edges in the global background graph. Setting xi=0 gives
+        disjoint communities while xi=1 gives a random graph with no community
+        structure.
 
     min_degree : int,  default=5
         Minimum degree in the graph. Not used if degree_sequence is passed.
@@ -40,21 +44,25 @@ class ABCD:
         Maximum degree in the graph. Not used if degree_sequence is passed.
 
     min_community_size : int, default=20
-        Minimum community size. Not used if a custom community_size_sequence is passed.
+        Minimum community size. Not used if a custom community_size_sequence
+        is passed.
 
     max_community_size: int, default=250
-        Maximum community size. Not used if a custom community_size_sequence is passed.
+        Maximum community size. Not used if a custom community_size_sequence
+        is passed.
 
     degree_sequence : Sequence[int] | NDArray[np.int64] | None, default=None
-        Used to pass a custom degree sequence that overrides the default powerlaw distribution.
+        Used to pass a custom degree sequence that overrides the default
+        powerlaw distribution.
 
     community_size_sequence : Sequence[int] | NDArray[np.int64] | None, default=None
-        Used to pass a custom community size sequence that overrides the default powerlaw distribution.
-        The sum of the community sizes must equal the number of vertices minus the number of outliers.
+        Used to pass a custom community size sequence that overrides the default
+        powerlaw distribution. The sum of the community sizes must equal the number
+        of vertices minus the number of outliers.
 
     num_outliers : int, default=0
-        The number of outliers. These vertices have their entire degree in the global background graph
-        so do not appear in any community.
+        The number of outliers. These vertices have their entire degree in the
+        global background graph so do not appear in any community.
 
     model : Model | None, default=None
         Random graph model used to sample the community and background graphs.
@@ -94,8 +102,8 @@ class ABCD:
         self.verbose = verbose
 
     def sample(self, callbacks: list[ABCDCallback] | None = None) -> ABCDGraph:
-        """Sample an ABCD graph. Calling sample multiple times will overwrite the
-        self.graph_ object."""
+        """Sample an ABCD graph. Calling sample multiple times will overwrite
+        the self.graph_ object."""
         self.params_ = ABCDParams(
             self.vcount,
             self.gamma if self.degree_sequence is None else None,

--- a/src/abcd_graph/graph/abcd.py
+++ b/src/abcd_graph/graph/abcd.py
@@ -3,7 +3,6 @@ from typing import Sequence
 import numpy as np
 from numpy.typing import NDArray
 
-
 from abcd_graph.callbacks.abstract import ABCDCallback
 from abcd_graph.graph import ABCDGraph
 from abcd_graph.models import Model

--- a/tests/abcd_graph/test_abcd.py
+++ b/tests/abcd_graph/test_abcd.py
@@ -1,4 +1,3 @@
-import pytest
 from abcd_graph import ABCD
 from tests.utils import assert_graph_built
 

--- a/tests/abcd_graph/test_abcd.py
+++ b/tests/abcd_graph/test_abcd.py
@@ -1,0 +1,9 @@
+import pytest
+from abcd_graph import ABCD
+from tests.utils import assert_graph_built
+
+def test_abcd_sample(params):
+    sampler = ABCD(1000)
+    sample = sampler.sample()
+    assert_graph_built(sample)
+    assert sample is sampler.graph_

--- a/tests/abcd_graph/test_abcd.py
+++ b/tests/abcd_graph/test_abcd.py
@@ -2,6 +2,7 @@ import pytest
 from abcd_graph import ABCD
 from tests.utils import assert_graph_built
 
+
 def test_abcd_sample(params):
     sampler = ABCD(1000)
     sample = sampler.sample()


### PR DESCRIPTION
This PR adds an alternative interface to generate ABCDGraph objects #64. It effectively adds a .sample() method to ABCDParams, which feels more in line scikit-learn. It also simplifies the code to sample many graphs from the same set of parameters.
